### PR TITLE
Update Gemfile to pull the latest RMQ version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'bubble-wrap', :github => 'rubymotion/BubbleWrap', :require => ['bubble-wrap
 gem 'formotion', :github => 'markrickert/formotion', :branch => 'texties'
 gem 'motion-takeoff'
 gem 'motion-blitz' # Wrapper gem for SVProgressHUD
-gem 'ruby_motion_query', :github => 'MohawkApps/rmq', :branch => 'textables'
+gem 'ruby_motion_query'
 # gem 'ruby_motion_query', path: '../rmq'
 
 # Rubygems

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,4 @@
 GIT
-  remote: git://github.com/MohawkApps/rmq.git
-  revision: 286c67885b7be3b7b0b88ecf4df0ef37f7f4ee1f
-  branch: textables
-  specs:
-    ruby_motion_query (0.5.1)
-
-GIT
   remote: git://github.com/hboon/motion-testflight.git
   revision: bb40de7f7c44d246c7c63927a048dd33b0607e68
   branch: takeoff-on-launch-only
@@ -70,6 +63,7 @@ GEM
     nap (0.6.0)
     open4 (1.3.0)
     rake (10.1.1)
+    ruby_motion_query (0.5.6)
     xcodeproj (0.14.1)
       activesupport (~> 3.0)
       colored (~> 1.2)
@@ -88,4 +82,4 @@ DEPENDENCIES
   motion-takeoff
   motion-testflight!
   rake (>= 0.9.4)
-  ruby_motion_query!
+  ruby_motion_query


### PR DESCRIPTION
The Gemfile was setup to pull a "Textables" branch from the RMQ project, but there is no longer such a branch.

Given this, and that the latest RMQ version appears to work well (locally), I modified the Gemfile for Textables to point to the latest RMQ master version available from RubyGems.
